### PR TITLE
update nav panel on different user action

### DIFF
--- a/webapp/src/org/zkoss/zss/app/ui/AppCtrl.java
+++ b/webapp/src/org/zkoss/zss/app/ui/AppCtrl.java
@@ -313,6 +313,10 @@ public class AppCtrl extends CtrlBase<Component> {
     private void createNavS(SheetImpl currentSheet) {
 
         try {
+            if(currentSheet.getEndRowIndex()<1) {
+                treeBucket.setModel(new DefaultTreeModel<Bucket<String>>(new BucketTreeNode<Bucket<String>>(null,new BucketTreeNodeCollection<Bucket<String>>())));
+                return;
+            }
             ss.setNavSBuckets(currentSheet.getDataModel().createNavS(currentSheet,0,0));
             createNavSTree(ss.getNavSBuckets());
             updateColModel(currentSheet);
@@ -646,6 +650,11 @@ public class AppCtrl extends CtrlBase<Component> {
         collaborationInfo.removeRelationship(username);
         ss.setBook(loadedBook);
         initSaveNotification(loadedBook);
+
+        SSheet currentsheet = ss.getSelectedSSheet();
+
+        if(currentsheet.getEndRowIndex()<1)
+            treeBucket.setModel(new DefaultTreeModel<Bucket<String>>(new BucketTreeNode<Bucket<String>>(null,new BucketTreeNodeCollection<Bucket<String>>())));
 
         pushAppEvent(AppEvts.ON_CHANGED_FILE_STATE, BookInfo.STATE_UNSAVED);
         pushAppEvent(AppEvts.ON_LOADED_BOOK, loadedBook);


### PR DESCRIPTION
-clear nav panel on sheet select (prevents nav tree computation for empty sheet), 
-clear nav panel on open sheet (destroys last created nav tree to clean up the nav panel)