### PR TITLE
Wrap Up

### DIFF
--- a/dataspread-ui/src/App.css
+++ b/dataspread-ui/src/App.css
@@ -58,6 +58,15 @@ div.item.stylebar-padding{
   border-right: 1px solid rgba(34,36,38,.1);
 }
 
+.rowHeaderMenu{
+  display: block !important;
+  position: absolute !important;
+  zIndex: 1000 !important;
+  backgroundColor: rgba(52,52,52,1) !important;
+  opacity: 1 !important;
+  width: 100% !important;
+  height: 10% !important;
+}
 /* div.separator{
   border-left:1px solid #38546d !important; 
   border-right:1px solid #16222c !important; 

--- a/dataspread-ui/src/dsgrid.js
+++ b/dataspread-ui/src/dsgrid.js
@@ -3,8 +3,8 @@ import {Dimmer, Loader} from 'semantic-ui-react'
 import {ArrowKeyStepper, AutoSizer, defaultCellRangeRenderer, Grid, ScrollSync} from './react-virtualized'
 import Draggable from "react-draggable";
 
-
 import Cell from './cell';
+import RowHeaderCell from './rowheadercell';
 import 'react-datasheet/lib/react-datasheet.css';
 import LRUCache from "lru-cache";
 import Stomp from 'stompjs';
@@ -218,7 +218,7 @@ export default class DSGrid extends Component {
                                                     height={height}
                                                     width={this.columnWidth}
                                                     style={{
-                                                        overflow: 'hidden'
+                                                        overflow: 'visible'
                                                     }}
                                                     scrollTop={scrollTop}
                                                     cellRenderer={this._rowHeaderCellRenderer}
@@ -226,6 +226,7 @@ export default class DSGrid extends Component {
                                                     columnCount={1}
                                                     rowCount={this.state.rows}
                                                     rowHeight={this.rowHeight}
+                                                    ref={(ref) => this.grid = ref}
                                                 />
                                             </div>
 
@@ -258,7 +259,8 @@ export default class DSGrid extends Component {
                                                  style={{
                                                      position: 'absolute',
                                                      left: this.columnWidth,
-                                                     top: this.rowHeight
+                                                     top: this.rowHeight,
+                                                     zIndex:-1
                                                  }}>
 
                                                 <ArrowKeyStepper
@@ -361,13 +363,32 @@ export default class DSGrid extends Component {
                                style
                            }) {
         return (
-            <div
+            <RowHeaderCell
                 key={key}
                 style={style}
-                className='rowHeaderCell'>
-                {rowIndex + 1}
-            </div>
+                value={rowIndex+1}
+                rowIndex={rowIndex}
+            />
         )
+        // return (
+        //     <div
+        //         key={key}
+        //         style={style}
+        //         className='rowHeaderCell'
+                // onContextMenu={function(e) {
+                //     return (
+                //         <div style={{
+                //     zIndex: '999',
+                //     width: '50%',
+                //     height: '50%',
+                //     backgroundColor: "green"
+                // }}>77777</div>
+                //     )
+                // }}
+        //         >
+        //         {rowIndex + 1}
+        //     </div>
+        // )
     }
 
     _columnHeaderCellRenderer ({

--- a/dataspread-ui/src/rowheadercell.js
+++ b/dataspread-ui/src/rowheadercell.js
@@ -1,0 +1,40 @@
+import React, {Component} from 'react';
+import 'semantic-ui-css/semantic.min.css';
+import { Container, Menu, Message } from "semantic-ui-react";
+import { ContextMenu, MenuItem, ContextMenuTrigger } from "react-contextmenu";
+
+export default class RowHeaderCell extends Component {
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            rowHeaderMenuVisible: false,
+        }
+
+        this.handleClick = this.handleClick.bind(this);
+    }
+
+    handleClick = (e, data) => {
+        console.log(data);
+    };
+
+    render() {
+        return (
+                <Container>
+                    <ContextMenuTrigger id="some_unique_identifier">
+                        <Message>{this.props.value}</Message>
+                    </ContextMenuTrigger>
+
+                    <Menu className='rowHeaderMenu' as={ContextMenu} id="some_unique_identifier" vertical >
+                        <MenuItem data={"above"} onClick={this.handleClick}>
+                            <Menu.Item>ContextMenu Item 1</Menu.Item>
+                        </MenuItem>
+
+                        <MenuItem data={"below"} onClick={this.handleClick}>
+                            <Menu.Item>ContextMenu Item 2</Menu.Item>
+                        </MenuItem>
+                    </Menu>
+                </Container>
+            )
+    }
+}

--- a/testcode/src/BTreeWithReverseTest.java
+++ b/testcode/src/BTreeWithReverseTest.java
@@ -1,9 +1,8 @@
 import org.model.DBContext;
 import org.model.DBHandler;
-import org.zkoss.zss.model.impl.BTree;
+import org.zkoss.zss.model.impl.CombinedBTree;
 import org.zkoss.zss.model.impl.CountedBTree;
 import org.zkoss.zss.model.impl.KeyBTree;
-import org.zkoss.zss.model.impl.CombinedBTree;
 import org.zkoss.zss.model.impl.statistic.AbstractStatistic;
 import org.zkoss.zss.model.impl.statistic.CombinedStatistic;
 import org.zkoss.zss.model.impl.statistic.CountStatistic;
@@ -12,22 +11,19 @@ import org.zkoss.zss.model.impl.statistic.KeyStatistic;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Random;
-import java.util.stream.IntStream;
 
-public class BTreeTest {
+public class BTreeWithReverseTest {
 
     public static void main(String[] args) {
-        deepTest();
+        simpleTest();
     }
 
     public static void deepTest(){
-        String url = "jdbc:postgresql://127.0.0.1:5432/ibd";
+        String url = "jdbc:postgresql://127.0.0.1:5432/Tony";
         String driver = "org.postgresql.Driver";
-        String userName = "mangesh";
-        String password = "mangesh";
+        String userName = "Tony";
+        String password = "";
         DBHandler.connectToDB(url, driver, userName, password);
         DBContext dbContext = new DBContext(DBHandler.instance.getConnection());
 
@@ -36,10 +32,10 @@ public class BTreeTest {
         dbContext.getConnection().close();
     }
     public static void simpleTest(){
-        String url = "jdbc:postgresql://127.0.0.1:5432/ibd";
+        String url = "jdbc:postgresql://127.0.0.1:5432/Tony";
         String driver = "org.postgresql.Driver";
-        String userName = "mangesh";
-        String password = "mangesh";
+        String userName = "Tony";
+        String password = "";
         DBHandler.connectToDB(url, driver, userName, password);
         DBContext dbContext = new DBContext(DBHandler.instance.getConnection());
         CountedBTree btree = new CountedBTree(dbContext, "Test1", false);

--- a/testcode/src/BTreeWithReverseTest.java
+++ b/testcode/src/BTreeWithReverseTest.java
@@ -20,14 +20,14 @@ import java.util.stream.IntStream;
 public class BTreeTest {
 
     public static void main(String[] args) {
-        simpleTest();
+        deepTest();
     }
 
     public static void deepTest(){
-        String url = "jdbc:postgresql://127.0.0.1:5432/Tony";
+        String url = "jdbc:postgresql://127.0.0.1:5432/ibd";
         String driver = "org.postgresql.Driver";
-        String userName = "Tony";
-        String password = "";
+        String userName = "mangesh";
+        String password = "mangesh";
         DBHandler.connectToDB(url, driver, userName, password);
         DBContext dbContext = new DBContext(DBHandler.instance.getConnection());
 
@@ -36,10 +36,10 @@ public class BTreeTest {
         dbContext.getConnection().close();
     }
     public static void simpleTest(){
-        String url = "jdbc:postgresql://127.0.0.1:5432/Tony";
+        String url = "jdbc:postgresql://127.0.0.1:5432/ibd";
         String driver = "org.postgresql.Driver";
-        String userName = "Tony";
-        String password = "";
+        String userName = "mangesh";
+        String password = "mangesh";
         DBHandler.connectToDB(url, driver, userName, password);
         DBContext dbContext = new DBContext(DBHandler.instance.getConnection());
         CountedBTree btree = new CountedBTree(dbContext, "Test1", false);

--- a/zssmodel/src/org/zkoss/zss/model/impl/CountedBTreeWithReverse.java
+++ b/zssmodel/src/org/zkoss/zss/model/impl/CountedBTreeWithReverse.java
@@ -1,0 +1,153 @@
+package org.zkoss.zss.model.impl;
+
+import org.model.BlockStore;
+import org.model.DBContext;
+import org.zkoss.zss.model.impl.statistic.AbstractStatistic;
+import org.zkoss.zss.model.impl.statistic.CountStatistic;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.TreeMap;
+
+//copy of CountedBTree with the addition of a reverser BTree.
+public class CountedBTreeWithReverse implements PosMappingWithValue{
+    BTree<CountStatistic> btree;
+    //Reverse Tree that maps a value(Tuple pointer) to the leaf node where this resides
+    //Actually we can use any tree structure that have logarithmic run time
+    //We will just use java's TreeMap for a map of key to Node.
+    TreeMap<Integer, BTree.Node> reverseTree;
+
+    //need to save at database as well. whenever the reverseTree is changed
+    public CountedBTreeWithReverse(DBContext context, String tableName, BlockStore sourceBlockStore) {
+        CountStatistic emptyStatistic = new CountStatistic();
+        btree = new BTree<>(context, tableName, sourceBlockStore, emptyStatistic, false);
+        reverseTree = new TreeMap<>();
+    }
+
+    public CountedBTreeWithReverse(DBContext context, String tableName) {
+        CountStatistic emptyStatistic = new CountStatistic();
+        btree = new BTree<>(context, tableName, emptyStatistic, true);
+        reverseTree = new TreeMap<>();
+    }
+
+    public CountedBTreeWithReverse(DBContext context, String tableName, boolean useKryo) {
+        CountStatistic emptyStatistic = new CountStatistic();
+        btree = new BTree<>(context, tableName, emptyStatistic, useKryo);
+        reverseTree = new TreeMap<>();
+    }
+
+    @Override
+    public void dropSchema(DBContext context) {
+        btree.dropSchema(context);
+    }
+
+    @Override
+    //For lookup, we keep it the same
+    public ArrayList<Integer> getIDs(DBContext context, int pos, int count) {
+        //if ((pos + count) > size(context))
+        //    createIDs(context, size(context), pos + count - size(context));
+        CountStatistic statistic = new CountStatistic(pos);
+        return btree.getIDs(context, statistic, count, AbstractStatistic.Type.COUNT);
+    }
+
+    @Override
+    public ArrayList<Integer> deleteIDs(DBContext context, ArrayList<Integer> values) {
+        //if ((pos + count) > size(context))
+        //    createIDs(context, size(context), pos + count - size(context));
+        ArrayList<Integer> deletedIDs = new ArrayList<>();
+        for(int i = 0;i < values.size();i++){
+            deletedIDs.add(deleteID(context, values.get(i)));
+        }
+        return deletedIDs;
+    }
+
+    public int deleteID(DBContext context, int value){
+        //lookup in the reverseTree
+        BTree.Node node = reverseTree.get(value);
+        if(node.leafNode == false){
+            //this should not happen
+            throw new RuntimeException("Not a leafnode where it should be");
+        }
+        int pos = 0;
+        for(int i = 0;i < node.values.size();i++){
+            if((int)node.values.get(i) == value){
+                //TODO: Verify this pos is correct for the deleteIDs method below
+                pos = i;
+                //remove from reverse tree
+                reverseTree.remove(value);
+            }
+        }
+        //remove from Btree
+        ArrayList<CountStatistic> statistics = new ArrayList<>();
+        //for (int i = 0; i < count; i++)
+        statistics.add(new CountStatistic(pos));
+        //only one value is returned.
+        return btree.deleteIDs(context, statistics, AbstractStatistic.Type.COUNT).get(0);
+    }
+
+    @Override
+    public void insertIDs(DBContext context, ArrayList<Integer> ids) {
+        int count = ids.size();
+        for (int i = 0; i < count; i++) {
+            insertID(context, ids.get(i));
+        }
+    }
+
+    public void insertID(DBContext context, int id){
+        ArrayList<CountStatistic> statistics = new ArrayList<>();
+        //TODO: Verify this is correct: end pos is size of context
+        statistics.add(new CountStatistic(size(context)+1));
+        BTree.Node inserted = btree.insertIDs(context, statistics,
+                new ArrayList<>(Arrays.asList(id)), AbstractStatistic.Type.COUNT);
+
+        reverseTree.put(id, inserted);
+    }
+
+    @Override
+    public ArrayList<Integer> createIDs(DBContext context, int pos, int count) {
+        Integer max_value = btree.getMaxValue();
+        CountStatistic statistic = new CountStatistic(pos);
+        ArrayList<Integer> ids = new ArrayList<>();
+
+        //update the createID to return the leafNode
+        BTree.Node leafNode = btree.createIDs(
+                context, statistic, max_value + 1, count, false, AbstractStatistic.Type.COUNT);
+
+        for (int i = 0; i < count; i++) {
+            //insert at reverseTree as well
+            reverseTree.put(max_value+1, leafNode);
+            ids.add(++max_value);
+        }
+        btree.updateMaxValue(context, max_value);
+        return ids;
+    }
+
+    @Override
+    public void clearCache(DBContext context) {
+        btree.clearCache(context);
+    }
+
+    @Override
+    public PosMapping clone(DBContext context, String tableName) {
+        return new CountedBTree(context, tableName, btree.bs);
+    }
+
+    @Override
+    public int size(DBContext context) {
+        return btree.size(context);
+    }
+
+    @Override
+    public String getTableName() {
+        return btree.getTableName();
+    }
+
+
+    public void useKryo(boolean useKryo) {
+        btree.useKryo(useKryo);
+    }
+
+    public void setBlockSize(int b) {
+        btree.setB(b);
+    }
+}

--- a/zssmodel/src/org/zkoss/zss/model/impl/PosMappingWithValue.java
+++ b/zssmodel/src/org/zkoss/zss/model/impl/PosMappingWithValue.java
@@ -1,0 +1,31 @@
+package org.zkoss.zss.model.impl;
+
+import org.model.DBContext;
+
+import java.util.ArrayList;
+
+public interface PosMappingWithValue {
+    void dropSchema(DBContext context);
+
+    // LookUp: Get IDs by index, this should not change since by index does not make sense
+    ArrayList getIDs(DBContext context, int pos, int count);
+
+    // Delete: remove count ID by its value and return the deleted ID
+    // delete one at a time
+    ArrayList deleteIDs(DBContext context, ArrayList<Integer> values);
+
+    // Insert: Add and return count IDs of values given
+    void insertIDs(DBContext context, ArrayList<Integer> ids);
+
+    //this is a Hack?
+    ArrayList createIDs(DBContext context, int pos, int count);
+
+    // Rollback and Flush Cache
+    void clearCache(DBContext context);
+
+    PosMapping clone(DBContext context, String tableName);
+
+    int size(DBContext context);
+
+    String getTableName();
+}


### PR DESCRIPTION
BackEnd: Implement `CountedBtreeWithReverse` class to support operations with value. 
- Current Progress: Implementation for the classes and interface is done. The original `CountedBTree` is left unmodified for future experiment. The underlying `BTree` is slightly modified to support the reverse tree. With the reverse tree, operations insert and delete are also updated. The reverse tree uses `TreeSet` and maps positional mapping id to the `BTree Node` that contains it. 
- Next Step: `BTreeTest` currently broken and debugging it needed. Need to fix it before conduct similar testing with the reverse tree. 

FrontEnd: Add menus for `RowHeader` and `ColHeader`to support insert/delete one row/column at that place
- Current Progress: Right click menu can pop up at the location when click on the rowHeader. The style issue is almost fixed by using the `!important` flag. Still since it is contained inside a `Grid`, the menu is still not on the top layer. In addition, the `CellRenderer` now returns `rowHeaderCell` where the right click event is handled inside.
- Challenge: To actually insert and delete a row, we need a list like structure to maintain all rows existing. However, since the header and the actual data are in separate components, we would need to think a way to either reorganize the code(i.e. use containers other than `Grid`) or get around the separation. 